### PR TITLE
Ensure tempfiles created from body-calendar are useable

### DIFF
--- a/lib/griddler/mailgun/adapter.rb
+++ b/lib/griddler/mailgun/adapter.rb
@@ -110,7 +110,7 @@ module Griddler
           ActionDispatch::Http::UploadedFile.new(
             filename: 'invite.ics',
             type: 'text/calendar',
-            tempfile: file
+            tempfile: file.open
           )
         ]
       end

--- a/spec/griddler/mailgun/adapter_spec.rb
+++ b/spec/griddler/mailgun/adapter_spec.rb
@@ -124,6 +124,13 @@ describe Griddler::Mailgun::Adapter, '.normalize_params' do
     expect(normalized_params[:bcc]).to eq []
   end
 
+  it 'creates a useable tempfile from the body-calendar params' do
+    params = default_params.merge(calendar_param)
+    normalized_params = Griddler::Mailgun::Adapter.normalize_params(params)
+    ics_attachment = normalized_params[:attachments].first
+    expect(File.exist? ics_attachment).to eq true
+  end
+
   def upload_1
     @upload_1 ||= ActionDispatch::Http::UploadedFile.new(
       filename: 'photo1.jpg',


### PR DESCRIPTION
Tempfile was closing the stream before it was used by actiondispatch
which meant that the file was garbage collected before it was used
by whatever needed it, but the pointer still existed